### PR TITLE
Docs: Add label parameter to Command Help section

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Options:
   --style        Badges style: flat, flat-square.
   --type         Coverage type: lines, statements, functions, branches.
   --icon         Path to icon file
+  --label        The left label of the badge, usually static (default `coverage`).
 
 Example:
 


### PR DESCRIPTION
This PR adds the `--label` CLI parameter to the Command Help section of the readme as it wasn't documented yet.